### PR TITLE
README: get api key from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ For lazy:
 ```lua
 {
     'skywind3000/vim-gpt-commit',
-    config = function () 
-        vim.g.gpt_commit_key = 'Your openai apikey'
+    config = function ()
+        -- if you don't want to set your api key directly, add to your .zshrc:
+        -- export OPENAI_API_KEY='sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+        vim.g.gpt_commit_key = os.getenv("OPENAI_API_KEY")
         -- uncomment this line below to enable proxy
         -- vim.g.gpt_commit_proxy = 'socks5://127.0.0.1:1080'
     end,


### PR DESCRIPTION
So users don't commit their api keys to their vimrc repos