### PR TITLE
Add support multiline prompt support

### DIFF
--- a/autoload/gptcommit/gpt.vim
+++ b/autoload/gptcommit/gpt.vim
@@ -75,6 +75,7 @@ function! gptcommit#gpt#generate(path) abort
 		let args += ['--concise']
 	endif
 	let prompt = get(g:, 'gpt_commit_prompt', '')
+	let prompt = join(prompt, "\n")
 	if prompt != ''
 		let args += ['--prompt=' . prompt]
 	endif


### PR DESCRIPTION
Vim allow to set multiline variables which is pretty helpful to define complex prompts about how to create a commit message.

```.vimrc
	let g:gpt_commit_prompt =<< EOF
	Your a funny commedian who works as dev to pay your bills.

	You will summarize the git changes (provided as a diff) and make out
	a dad joke as a title, followed by a blank line, and a summary of the
	actual changes.

	EOF
```

However as a result of this it will store the text as an list. This will make the plugin crash, as it tries to compare a list to a string ("" == prompt).

This commit fixes that problem by using join as suggested in this post:
https://github.com/vim/vim/issues/1337