### PR TITLE
Add git log context to the prompt if gpt_gpt_commit_max_logs is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You will see the result in the command line.
 | g:gpt_commit_model | - | `'gpt-3.5-turbo'` | ChatGPT model |
 | g:gpt_commit_staged | - | `1` | set to 1 to use staged diff |
 | g:gpt_commit_max_line | - | `160` | max diff lines to reference |
-| g:gpt_gpt_commit_max_logs | - | `5` | max log history (git log) use as context |
+| g:gpt_gpt_commit_max_logs | - | `0` | max log history (git log) use as context |
 | g:gpt_commit_url | - | `''` | alternative request URL, see #1 |
 | g:gpt_commit_python | - | `''` | specify the Python executable file explicitly |
 | g:gpt_commit_engine | - | `'chatgpt'` | change to 'ollama' to use Ollama |

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ You will see the result in the command line.
 | g:gpt_commit_model | - | `'gpt-3.5-turbo'` | ChatGPT model |
 | g:gpt_commit_staged | - | `1` | set to 1 to use staged diff |
 | g:gpt_commit_max_line | - | `160` | max diff lines to reference |
+| g:gpt_gpt_commit_max_logs | - | `5` | max log history (git log) use as context |
 | g:gpt_commit_url | - | `''` | alternative request URL, see #1 |
 | g:gpt_commit_python | - | `''` | specify the Python executable file explicitly |
 | g:gpt_commit_engine | - | `'chatgpt'` | change to 'ollama' to use Ollama |
@@ -102,6 +103,7 @@ available options:
   --concise       optional, generate concise message if present
   --utf8          optional, output utf-8 encoded text if present
   --url=xxx       optional, alternative openai request url
+  --maxlogs=num   optional, use git <num> log entries to enrich the context
 ```
 
 It can be integrated into other editors. 

--- a/autoload/gptcommit/gpt.vim
+++ b/autoload/gptcommit/gpt.vim
@@ -78,6 +78,10 @@ function! gptcommit#gpt#generate(path) abort
 	if prompt != ''
 		let args += ['--prompt=' . prompt]
 	endif
+	let maxlogs = get(g:, 'gpt_commit_max_logs', 0)
+	if maxlogs > 0
+		let args += ['--maxlogs=' . maxlogs]
+	endif
 	if get(g:, 'gpt_commit_fake', 0)
 		let args += ['--fake']
 	endif

--- a/bin/gptcommit.py
+++ b/bin/gptcommit.py
@@ -185,11 +185,11 @@ def GitDiff(path, staged = False):
 #----------------------------------------------------------------------
 # get git log
 #----------------------------------------------------------------------
-def GitLog(path):
+def GitLog(path, maxlogs = DEFAULT_MAX_LOGS_HISTORY):
     previous = os.getcwd()
     if path:
         os.chdir(path)
-    logs = CallGit('log', '--pretty=format:%s', '-n', '10') or 'No logs'
+    logs = CallGit('log', '--pretty=format:%s', '-n', maxlogs) or 'No logs'
     if 'fatal: your current branch' in logs:
         logs = ''
     os.chdir(previous)
@@ -451,7 +451,7 @@ Git Changes:
         git_logs_text += f'''
 Previous Git Logs:
 ----------------
-{GitLog(OPTIONS["path"])}
+{GitLog(OPTIONS["path"], OPTIONS["maxlogs"])}
 ----------------
 
 Use the previous Git Logs as context for the Git Changes

--- a/bin/gptcommit.py
+++ b/bin/gptcommit.py
@@ -174,10 +174,22 @@ def GitDiff(path, staged = False):
     previous = os.getcwd()
     if path:
         os.chdir(path)
+    text = 'Git Diff: \n'
     if staged:
-        text = CallGit('diff', '--staged')
+        text += CallGit('diff', '--staged')
     else:
-        text = CallGit('diff')
+        text += CallGit('diff')
+    os.chdir(previous)
+    return text
+
+#----------------------------------------------------------------------
+# get git log
+#----------------------------------------------------------------------
+def GitLog(path):
+    previous = os.getcwd()
+    if path:
+        os.chdir(path)
+    text = 'Git logs: \n' + CallGit('log', '--pretty=format:%s', '-n', '10')
     os.chdir(previous)
     return text
 
@@ -420,6 +432,8 @@ def main(argv = None):
         print('Not a repository: %s'%path)
         return 3
     content = GitDiff(OPTIONS['path'], OPTIONS['staged'])
+    content += '\n\n'
+    content += GitLog(OPTIONS['path'])
     msgs = MakeMessages(content, OPTIONS)
     if msgs[1]['content'] == '':
         print('No changes')

--- a/bin/gptcommit.py
+++ b/bin/gptcommit.py
@@ -174,11 +174,10 @@ def GitDiff(path, staged = False):
     previous = os.getcwd()
     if path:
         os.chdir(path)
-    text = 'Git Diff: \n'
     if staged:
-        text += CallGit('diff', '--staged')
+        text = CallGit('diff', '--staged')
     else:
-        text += CallGit('diff')
+        text = CallGit('diff')
     os.chdir(previous)
     return text
 
@@ -189,9 +188,11 @@ def GitLog(path):
     previous = os.getcwd()
     if path:
         os.chdir(path)
-    text = 'Git logs: \n' + CallGit('log', '--pretty=format:%s', '-n', '10')
+    logs = CallGit('log', '--pretty=format:%s', '-n', '10') or 'No logs'
+    if 'fatal: your current branch' in logs:
+        logs = ''
     os.chdir(previous)
-    return text
+    return logs
 
 
 #----------------------------------------------------------------------
@@ -431,9 +432,21 @@ def main(argv = None):
     if not root:
         print('Not a repository: %s'%path)
         return 3
-    content = GitDiff(OPTIONS['path'], OPTIONS['staged'])
-    content += '\n\n'
-    content += GitLog(OPTIONS['path'])
+    
+    content = f'''
+Git Changes:
+----------------
+{GitDiff(OPTIONS["path"], OPTIONS["staged"])}
+----------------
+
+Previous Git Logs:
+----------------
+{GitLog(OPTIONS["path"])}
+----------------
+
+Use the git changes and previous logs for context to complete the
+instructions that follows.
+'''
     msgs = MakeMessages(content, OPTIONS)
     if msgs[1]['content'] == '':
         print('No changes')

--- a/bin/gptcommit.py
+++ b/bin/gptcommit.py
@@ -137,7 +137,7 @@ def CallGit(*args):
 # lazy request
 #----------------------------------------------------------------------
 DEFAULT_MAX_LINE = 160
-DEFAULT_MAX_LOGS_HISTORY = 5
+DEFAULT_MAX_LOGS_HISTORY = 0
 
 
 #----------------------------------------------------------------------
@@ -446,8 +446,9 @@ Git Changes:
 
 '''
 
+    git_logs_text = ''
     if OPTIONS['maxlogs'] > 0:
-        git_logs_text = f'''
+        git_logs_text += f'''
 Previous Git Logs:
 ----------------
 {GitLog(OPTIONS["path"])}

--- a/bin/gptcommit.py
+++ b/bin/gptcommit.py
@@ -448,7 +448,9 @@ Git Changes:
 
     git_logs_text = ''
     if OPTIONS['maxlogs'] > 0:
-        git_logs_text += f'''
+        content_size = len(git_changes_text.splitlines()) + (OPTIONS['maxlogs'] + 6) + 1
+        if content_size > OPTIONS.get('maxline', DEFAULT_MAX_LINE):
+            git_logs_text = f'''
 Previous Git Logs:
 ----------------
 {GitLog(OPTIONS["path"], OPTIONS["maxlogs"])}
@@ -457,9 +459,6 @@ Previous Git Logs:
 Use the previous Git Logs as context for the Git Changes
 provided above. 
 '''
-        content_size = len(git_changes_text.splitlines()) + len(git_logs_text.splitlines()) + 1
-        if content_size > OPTIONS.get('maxline', DEFAULT_MAX_LINE):
-            git_logs_text = ''
 
     content = f'''
 {git_changes_text}

--- a/bin/gptcommit.py
+++ b/bin/gptcommit.py
@@ -137,6 +137,7 @@ def CallGit(*args):
 # lazy request
 #----------------------------------------------------------------------
 DEFAULT_MAX_LINE = 160
+DEFAULT_MAX_LOGS_HISTORY = 5
 
 
 #----------------------------------------------------------------------
@@ -349,6 +350,7 @@ def help():
     print('  --concise       optional, generate concise message if present')
     print('  --utf8          optional, output utf-8 encoded text if present')
     print('  --url=xxx       optional, alternative openai request url')
+    print('  --maxlogs=num   optional, use git <num> log entries to enrich the context')
     print()
     return 0
 
@@ -427,25 +429,41 @@ def main(argv = None):
             return 2
     else:
         OPTIONS['path'] = os.getcwd()
+
+    OPTIONS['maxlogs'] = int(options.get('maxlogs', DEFAULT_MAX_LOGS_HISTORY))
+
     path = OPTIONS['path']
     root = CheckRepo(path)
     if not root:
         print('Not a repository: %s'%path)
         return 3
     
-    content = f'''
+    git_changes_text = f'''
 Git Changes:
 ----------------
 {GitDiff(OPTIONS["path"], OPTIONS["staged"])}
 ----------------
 
+'''
+
+    if OPTIONS['maxlogs'] > 0:
+        git_logs_text = f'''
 Previous Git Logs:
 ----------------
 {GitLog(OPTIONS["path"])}
 ----------------
 
-Use the git changes and previous logs for context to complete the
-instructions that follows.
+Use the previous Git Logs as context for the Git Changes
+provided above. 
+'''
+        content_size = len(git_changes_text.splitlines()) + len(git_logs_text.splitlines()) + 1
+        if content_size > OPTIONS.get('maxline', DEFAULT_MAX_LINE):
+            git_logs_text = ''
+
+    content = f'''
+{git_changes_text}
+{git_logs_text}
+With your instructions, the context, and git changes, make a commit message. 
 '''
     msgs = MakeMessages(content, OPTIONS)
     if msgs[1]['content'] == '':


### PR DESCRIPTION
The idea was to provide extra input to the prompt regarding the previous changes.

To do that what I've done is to get the git history using `git log --pretty=format:%s` and limiting the history to a number of lines defined by `g:gpt_gpt_commit_max_logs`. If gpt_gpt_commit_max_logs is not set or set to 0, no git log history will be attached. Else `git log --pretty=format:%s -n <max_logs>` will be called.
I have respected the original way to truncate the diff when invoking MakeMessage(), so if the aggregate number of lines of (git diff, git log, and some instructions) is more than the max_lines, it won't be appended. 