### PR TITLE
Fix handling of gpt_commit_prompt when it's a list

### DIFF
--- a/autoload/gptcommit/gpt.vim
+++ b/autoload/gptcommit/gpt.vim
@@ -75,7 +75,9 @@ function! gptcommit#gpt#generate(path) abort
 		let args += ['--concise']
 	endif
 	let prompt = get(g:, 'gpt_commit_prompt', '')
-	let prompt = join(prompt, "\n")
+    if type(prompt) == v:t_list
+        let prompt = join(prompt, "\n")
+    endif
 	if prompt != ''
 		let args += ['--prompt=' . prompt]
 	endif


### PR DESCRIPTION
- Ensure prompt variable is properly joined with newlines only when it's a list type
- Prevent errors when g:gpt_commit_prompt is not configured